### PR TITLE
Refactor: Separate retrieval and generation logic

### DIFF
--- a/app/controllers/api/v1/chats_controller.rb
+++ b/app/controllers/api/v1/chats_controller.rb
@@ -29,7 +29,7 @@ module Api
 
       def process_chat_request(question, persona)
         rag_service = RagService.new(persona: persona)
-        response = rag_service.query(question)
+        response = rag_service.call(question)
 
         respond_to do |format|
           format.json { render json: response }

--- a/app/services/document_retriever_service.rb
+++ b/app/services/document_retriever_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class DocumentRetrieverService
+  DEFAULT_MAX_CONTEXT_DOCS = 50
+  DEFAULT_SIMILARITY_METRIC = "cosine"
+
+  def initialize(question_embedding)
+    @question_embedding = question_embedding
+  end
+
+  def call
+    find_relevant_documents(@question_embedding, DEFAULT_MAX_CONTEXT_DOCS)
+  end
+
+  private
+
+  def find_relevant_documents(embedding, max_docs)
+    Chunk.nearest_neighbors(
+      :embedding,
+      embedding,
+      distance: DEFAULT_SIMILARITY_METRIC
+    ).first(max_docs)
+  rescue StandardError => e
+    Rails.logger.error("Document retrieval failed: #{e.message}")
+    []
+  end
+end

--- a/app/services/embedding_service.rb
+++ b/app/services/embedding_service.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class EmbeddingService
+  DEFAULT_EMBEDDING_MODEL = "text-embedding-ada-002"
+
   def initialize(content)
     @content = content
   end
@@ -15,7 +17,7 @@ class EmbeddingService
     client = Llm::OpenAI::Client.new
     response = client.embeddings(
       parameters: {
-        model: "text-embedding-ada-002",
+        model: DEFAULT_EMBEDDING_MODEL,
         input: @content
       }
     )

--- a/app/services/query_embedding_service.rb
+++ b/app/services/query_embedding_service.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class QueryEmbeddingService
+  def initialize(user_question)
+    @user_question = user_question
+  end
+
+  def call
+    generate_embedding
+  end
+
+  private
+
+  def generate_embedding
+    embedding_service = EmbeddingService.new(@user_question)
+
+    embedding_service.call
+  rescue StandardError => e
+    raise AIAssistant::Errors::EmbeddingGenerationError, "Failed to generate embedding: #{e.message}"
+  end
+end

--- a/app/services/rag_service.rb
+++ b/app/services/rag_service.rb
@@ -1,122 +1,48 @@
 # frozen_string_literal: true
 
 class RagService
-  # Constants for default values
   DEFAULT_MODEL = "gpt-3.5-turbo"
-  DEFAULT_EMBEDDING_MODEL = "text-embedding-ada-002"
-  DEFAULT_MAX_CONTEXT_DOCS = 50
-  DEFAULT_SIMILARITY_METRIC = "cosine"
   DEFAULT_PERSONA = :professional
 
   def initialize(
     client: Llm::OpenAI::Client.new,
-    embedding_model: DEFAULT_EMBEDDING_MODEL,
     model: DEFAULT_MODEL,
     persona: DEFAULT_PERSONA
   )
     @client = client
-    @embedding_model = embedding_model
     @model = model
     @persona = AIAssistant::PersonaRegistry.find(persona)
   end
 
-  def query(user_question, max_context_docs: DEFAULT_MAX_CONTEXT_DOCS)
-    question_embedding = generate_embedding(user_question)
-    relevant_docs = find_relevant_documents(question_embedding, max_context_docs)
-    response = generate_response(user_question, relevant_docs)
+  def call(user_question)
+    embed_query(user_question)
 
-    build_response(user_question, response, relevant_docs)
-  rescue StandardError => e
-    handle_query_error(e)
-  end
+    retrieve_documents
 
-  def add_document(title:, content:)
-    validate_document!(title, content)
-
-    Document.create!(
-      title: title,
-      content: content,
-      embedding: generate_embedding(content)
-    )
-  rescue StandardError => e
-    handle_document_error(e)
+    generate_response(user_question)
   end
 
   private
 
-  def validate_document!(content)
-    raise AIAssistant::Errors::InvalidDocumentError, "Content cannot be blank" if content.blank?
+  def embed_query(user_question)
+    query_embedding = QueryEmbeddingService.new(user_question)
+
+    @question_embedding ||= query_embedding.call
   end
 
-  def generate_embedding(content)
-    embedding_service = EmbeddingService.new(content)
+  def generate_response(question)
+    response_generator = ResponseGeneratorService.new(
+                          @client,
+                          @model,
+                          @persona
+                        )
 
-    embedding_service.call
-  rescue StandardError => e
-    raise AIAssistant::Errors::EmbeddingGenerationError, "Failed to generate embedding: #{e.message}"
+    response_generator.call(question, @documents)
   end
 
-  def find_relevant_documents(embedding, max_docs)
-    Chunk.nearest_neighbors(
-      :embedding,
-      embedding,
-      distance: DEFAULT_SIMILARITY_METRIC
-    ).first(max_docs)
-  rescue StandardError => e
-    Rails.logger.error("Document retrieval failed: #{e.message}")
-    []
-  end
+  def retrieve_documents
+    document_retriever = DocumentRetrieverService.new(@question_embedding)
 
-  def generate_response(question, documents)
-    return "No relevant information found." if documents.empty?
-
-    context = build_context(documents)
-    prompt = build_prompt(context, question)
-
-    @client.query(@model, prompt)
-  rescue StandardError => e
-    raise AIAssistant::Errors::QueryProcessingError, "Failed to generate response: #{e.message}"
-  end
-
-  def build_context(documents)
-    documents.map do |doc|
-      "#{doc.content}"
-    end.join("\n\n")
-  end
-
-  def build_prompt(context, question)
-    <<~PROMPT
-      #{@persona.system_prompt}
-
-      Use the following context to answer the question based on the given persona.
-      If you cannot answer the question based on the context, say so.
-
-      Never mention the word "based on the context provided" or anything similar to this phrase in your response.
-
-      Context:
-      #{context}
-
-      Question: #{question}
-    PROMPT
-  end
-
-  def build_response(question, answer, sources)
-    {
-      question: question,
-      answer: answer,
-      sources: "#{sources.first.document.name} - Temporary source",
-      # sources: "#{sources.map(&:chunk_index).join(", ")} - Temporary sources",
-      persona: @persona.name
-    }
-  end
-
-  def handle_query_error(error)
-    Rails.logger.error("Query failed: #{error.message}")
-    raise AIAssistant::Errors::QueryError, "Failed to process query: #{error.message}"
-  end
-
-  def handle_document_error(error)
-    Rails.logger.error("Failed to add document: #{error.message}")
-    raise AIAssistant::Errors::DocumentCreationError, "Failed to add document: #{error.message}"
+    @documents ||= document_retriever.call
   end
 end

--- a/app/services/response_generator_service.rb
+++ b/app/services/response_generator_service.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class ResponseGeneratorService
+  def initialize(client, model, persona)
+    @client = client
+    @model = model
+    @persona = persona
+  end
+
+  def call(question, documents)
+    llm_answer = generate_llm_answer(question, documents)
+
+    build_response(question, llm_answer, documents)
+  end
+
+  private
+
+  def build_context(documents)
+    documents.map do |doc|
+      "#{doc.content}"
+    end.join("\n\n")
+  end
+
+  def build_prompt(context, question)
+    <<~PROMPT
+      #{@persona.system_prompt}
+
+      Use the following context to answer the question based on the given persona.
+      If you cannot answer the question based on the context, say so.
+
+      Never mention the word "based on the context provided" or anything similar to this phrase in your response.
+
+      Context:
+      #{context}
+
+      Question: #{question}
+    PROMPT
+  end
+
+  def build_response(question, answer, sources)
+    {
+      question: question,
+      answer: answer,
+      sources: "#{sources.first.document.name}",
+      persona: @persona.name
+    }
+  end
+
+  def generate_llm_answer(question, documents)
+    return "No relevant information found." if documents.empty?
+
+    context = build_context(documents)
+    prompt = build_prompt(context, question)
+
+    @client.query(@model, prompt)
+  rescue StandardError => e
+    raise AIAssistant::Errors::QueryProcessingError, "Failed to generate response: #{e.message}"
+  end
+end


### PR DESCRIPTION
### What?

- Added new services namely `QueryEmbeddingService`, `DocumentRetrieverService`, and `ResponseGeneratorService`
- Refactored the existing `RagService`

### Why?

- During the initial experimentation of performing retrieval-augmented generation, all of the processes necessary are cluttered inside one service. This is quite hard to read and maintain, hence the decision of separating the steps into their own service for better readability and maintainability.

### Screenshots

<details>
<summary>Working `/chat` endpoint despite of the changes</summary>
<img width="1682" alt="Screenshot 2025-07-09 at 2 25 44 PM" src="https://github.com/user-attachments/assets/afe74a99-ad5e-48c4-bef5-759f0cbee74c" />
<img width="1682" alt="Screenshot 2025-07-09 at 2 27 37 PM" src="https://github.com/user-attachments/assets/cf57f3b8-e2e0-46a3-84f7-a7b2e3f96804" />

</details>