### PR TITLE
Enable Saving of User Chat and Rukia's Reponse

### DIFF
--- a/app/controllers/api/v1/chats_controller.rb
+++ b/app/controllers/api/v1/chats_controller.rb
@@ -3,18 +3,28 @@
 module Api
   module V1
     class ChatsController < ApplicationController
-      before_action :authenticate_user!, only: [ :chat ]
+      before_action :authenticate_user!,
+                    :set_question,
+                    :set_document,
+                    :set_persona, only: [ :chat ]
+
+      after_action :record_llm_response, only: [ :chat ]
+
+      attr_accessor :question, :document, :persona, :message
 
       def index
         # This will render the chat interface
       end
 
       def chat
-        question = params[:question]
-        persona = params[:persona]&.to_sym || :professional
+        validate_question!
+        record_question
 
-        validate_question!(question)
-        process_chat_request(question, persona)
+        @response = process_retrieval_and_generation
+
+        respond_to do |format|
+          format.json { render json: @response }
+        end
       rescue AIAssistant::Errors::Base => e
         handle_ai_error(e)
       rescue StandardError => e
@@ -23,17 +33,44 @@ module Api
 
       private
 
-      def validate_question!(question)
+      def set_question
+        @question = params[:question]
+      end
+
+      def set_document
+        @document = Document.find_by(id: params[:document_id])
+
+        raise ActiveRecord::RecordNotFound, "Document not found" unless document
+      end
+
+      def set_persona
+        @persona = params[:persona]&.to_sym || :professional
+      end
+
+      def record_question
+       @message = Message.create!(
+          body: question,
+          document: document,
+        )
+      end
+
+      def record_llm_response
+        LlmResponse.create!(
+          body: @response[:answer],
+          persona: @response[:persona],
+          source: @response[:source],
+          message: message
+        )
+      end
+
+      def validate_question!
         raise AIAssistant::Errors::InvalidQueryError, "Question parameter is required" if question.blank?
       end
 
-      def process_chat_request(question, persona)
-        rag_service = RagService.new(persona: persona)
-        response = rag_service.call(question)
+      def process_retrieval_and_generation
+        rag_service = RagService.new(persona: persona, document: document)
 
-        respond_to do |format|
-          format.json { render json: response }
-        end
+        rag_service.call(question)
       end
 
       def handle_ai_error(error)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -3,8 +3,11 @@
 class Document < ApplicationRecord
   include Embeddable
 
+  belongs_to :user
+
   has_one_attached :file
   has_many :chunks, dependent: :destroy
+  has_many :messages, dependent: :destroy
 
   enum status: {
     uploaded: 0,
@@ -42,7 +45,7 @@ class Document < ApplicationRecord
       next if content.empty?
 
       Rails.logger.info "Chunk data: #{content}"
-
+      # Placeholder for actual token count logic
       chunk_data_params = {
         content: content,
         chunk_index: index,

--- a/app/models/llm_response.rb
+++ b/app/models/llm_response.rb
@@ -1,0 +1,5 @@
+class LlmResponse < ApplicationRecord
+  belongs_to :message
+
+  validates :body, presence: true
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Message < ApplicationRecord
+  include Embeddable
+
+  belongs_to :document
+  has_neighbors :embedding
+
+  has_many :llm_responses, dependent: :destroy
+
+  before_validation :generate_embedding
+
+  validates :body, presence: true
+
+  private
+
+  # check if this can be done in background job
+  # this might be too slow for real-time chat
+  def generate_embedding
+    embedding_service = EmbeddingService.new(body)
+
+    self.embedding = embedding_service.call
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :jwt_authenticatable, jwt_revocation_strategy: self
 
+  has_many :messages, through: :documents
   def jwt_payload
     super
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,10 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :jwt_authenticatable, jwt_revocation_strategy: self
 
+  has_many :documents, dependent: :destroy
   has_many :messages, through: :documents
+  has_many :llm_responses, through: :messages
+
   def jwt_payload
     super
   end

--- a/app/services/document_retriever_service.rb
+++ b/app/services/document_retriever_service.rb
@@ -4,8 +4,9 @@ class DocumentRetrieverService
   DEFAULT_MAX_CONTEXT_DOCS = 50
   DEFAULT_SIMILARITY_METRIC = "cosine"
 
-  def initialize(question_embedding)
+  def initialize(question_embedding, document)
     @question_embedding = question_embedding
+    @document = document
   end
 
   def call
@@ -15,7 +16,7 @@ class DocumentRetrieverService
   private
 
   def find_relevant_documents(embedding, max_docs)
-    Chunk.nearest_neighbors(
+    @document.chunks.nearest_neighbors(
       :embedding,
       embedding,
       distance: DEFAULT_SIMILARITY_METRIC

--- a/app/services/document_uploader_service.rb
+++ b/app/services/document_uploader_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class DocumentUploaderService
+  def initialize(user:, file:)
+    @user = user
+    @file = file
+  end
+
+  def call
+    document = @user.documents.new(
+      name: @file.original_filename,
+      file_type: @file.content_type,
+      status: :processing,
+      is_active: true,
+      file: @file
+    )
+
+    if document.save
+      ProcessDocumentJob.perform_later(document.id)
+      { success: true, document: document }
+    else
+      { success: false, errors: document.errors.full_messages }
+    end
+  end
+end

--- a/app/services/rag_service.rb
+++ b/app/services/rag_service.rb
@@ -1,17 +1,20 @@
 # frozen_string_literal: true
 
 class RagService
+  # byebug
   DEFAULT_MODEL = "gpt-3.5-turbo"
   DEFAULT_PERSONA = :professional
 
   def initialize(
     client: Llm::OpenAI::Client.new,
     model: DEFAULT_MODEL,
-    persona: DEFAULT_PERSONA
+    persona: DEFAULT_PERSONA,
+    document: nil
   )
     @client = client
     @model = model
     @persona = AIAssistant::PersonaRegistry.find(persona)
+    @document = document
   end
 
   def call(user_question)
@@ -20,6 +23,10 @@ class RagService
     retrieve_documents
 
     generate_response(user_question)
+  rescue AIAssistant::Errors::EmbeddingError => e
+    raise e
+  rescue AIAssistant::Errors::ResponseRecordingError => e
+    raise e
   end
 
   private
@@ -41,7 +48,9 @@ class RagService
   end
 
   def retrieve_documents
-    document_retriever = DocumentRetrieverService.new(@question_embedding)
+    document_retriever = DocumentRetrieverService.new(
+      @question_embedding,
+      @document)
 
     @documents ||= document_retriever.call
   end

--- a/app/services/response_generator_service.rb
+++ b/app/services/response_generator_service.rb
@@ -41,7 +41,7 @@ class ResponseGeneratorService
     {
       question: question,
       answer: answer,
-      sources: "#{sources.first.document.name}",
+      source: "#{sources.first.document.name}",
       persona: @persona.name
     }
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
       post "chat", to: "chats#chat"
 
       # Document routes
-      resources :documents
+      resources :documents, only: [ :index, :create, :destroy ]
     end
   end
 end

--- a/db/migrate/20250709074647_create_messages.rb
+++ b/db/migrate/20250709074647_create_messages.rb
@@ -1,0 +1,12 @@
+class CreateMessages < ActiveRecord::Migration[7.2]
+  def change
+    create_table :messages do |t|
+      t.belongs_to :document, null: false, foreign_key: true
+      t.string :body, null: false
+      t.vector :embedding, null: false, limit: 1536
+      t.integer :token_count
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250709075200_create_llm_responses.rb
+++ b/db/migrate/20250709075200_create_llm_responses.rb
@@ -1,0 +1,13 @@
+class CreateLlmResponses < ActiveRecord::Migration[7.2]
+  def change
+    create_table :llm_responses do |t|
+      t.belongs_to :message, null: false, foreign_key: true
+      t.string :body, null: false
+      t.integer :token_count
+      t.string :persona
+      t.string :source
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250710044702_add_user_ref_to_document.rb
+++ b/db/migrate/20250710044702_add_user_ref_to_document.rb
@@ -1,0 +1,5 @@
+class AddUserRefToDocument < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :documents, :user, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -65,6 +65,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_08_044916) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
 
+  create_table "llm_responses", force: :cascade do |t|
+    t.bigint "message_id", null: false
+    t.string "body", null: false
+    t.integer "token_count"
+    t.string "persona"
+    t.string "source"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["message_id"], name: "index_llm_responses_on_message_id"
+  end
+
   create_table "messages", force: :cascade do |t|
     t.bigint "document_id", null: false
     t.string "body", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_08_044916) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_10_044702) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "vector"
@@ -64,6 +64,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_08_044916) do
     t.integer "token_count"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_documents_on_user_id"
+  end
 
   create_table "llm_responses", force: :cascade do |t|
     t.bigint "message_id", null: false
@@ -103,4 +106,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_08_044916) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "chunks", "documents"
+  add_foreign_key "documents", "users"
+  add_foreign_key "llm_responses", "messages"
+  add_foreign_key "messages", "documents"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,6 +64,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_08_044916) do
     t.integer "token_count"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+
+  create_table "messages", force: :cascade do |t|
+    t.bigint "document_id", null: false
+    t.string "body", null: false
+    t.vector "embedding", limit: 1536, null: false
+    t.integer "token_count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["document_id"], name: "index_messages_on_document_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,64 +1,64 @@
-# Clear existing documents
-puts "Deleting all existing documents..."
-Document.destroy_all
-puts "All existing documents deleted."
+# # Clear existing documents
+# puts "Deleting all existing documents..."
+# Document.destroy_all
+# puts "All existing documents deleted."
 
-sample_documents = [
-  {
-    title: "Company Return Policy",
-    content: "Our return policy is designed to ensure customer satisfaction. Items can be returned within 30 days of purchase with a valid receipt. All items must be in their original condition with tags attached. For online purchases, shipping costs will be refunded only if the return is due to our error. Customized items are non-returnable unless defective. Electronics must be returned within 14 days and cannot be returned if opened unless defective."
-  },
-  {
-    title: "Employee Remote Work Guidelines",
-    content: "Remote work is available to all full-time employees after 90 days of employment. Employees must maintain core hours of 10 AM to 3 PM in their local time zone for meetings and collaboration. A reliable internet connection with minimum 10Mbps speed is required. Remote workers must attend the monthly virtual team meeting and quarterly in-person meetings. Time tracking is required through our project management system. Equipment including laptop and monitor will be provided by the company."
-  },
-  {
-    title: "Product: Smart Home Hub",
-    content: "The SmartLife Hub is our flagship smart home controller. Key features include: Voice control support for Alexa and Google Assistant, Z-Wave and Zigbee protocol support, automated scene creation, energy usage monitoring, and mobile app control. The hub can connect up to 100 devices simultaneously and includes built-in backup battery support for up to 4 hours of operation during power outages. Retail price: $199.99. Available in white and black colors."
-  },
-  {
-    title: "Customer Service Standards",
-    content: "Our customer service representatives must respond to all inquiries within 24 hours. Phone support is available 24/7 for urgent issues. Email responses should be personalized and address all customer concerns. Chat support is available Monday through Friday, 9 AM to 6 PM EST. Escalation to a supervisor is available upon customer request. All customer interactions must be logged in our CRM system with detailed notes."
-  },
-  {
-    title: "Shipping Information",
-    content: "Standard shipping takes 3-5 business days within the continental US. Express shipping (1-2 business days) is available for an additional $15. International shipping is available to select countries and typically takes 7-14 business days. Free shipping is provided on orders over $50. All orders are processed within 24 hours Monday through Friday. Tracking information is automatically sent via email once the order ships. Signature may be required for items valued over $200."
-  },
-  {
-    title: "Product Warranty Terms",
-    content: "All products come with a standard 1-year warranty covering manufacturing defects. Premium products include an extended 3-year warranty. Warranty covers parts and labor for repairs. Accidental damage is not covered unless additional protection plan is purchased. Warranty is transferable to new owners. Battery replacement is covered for the first year only. Registration must be completed within 30 days of purchase to activate warranty coverage."
-  },
-  {
-    title: "Privacy Policy Highlights",
-    content: "We collect only essential customer data needed for order processing and service improvement. Personal information is never sold to third parties. Data is encrypted using industry-standard protocols. Customers can request their data be deleted at any time. Cookie usage is limited to essential website functionality and can be disabled. Marketing emails are opt-in only and can be disabled at any time. We conduct regular security audits to ensure data protection."
-  },
-  {
-    title: "Payment Methods",
-    content: "We accept all major credit cards including Visa, MasterCard, American Express, and Discover. PayPal and Apple Pay are supported for online purchases. Corporate purchase orders are accepted for business accounts. Payment plans are available for purchases over $500 with approved credit. All transactions are processed in USD. International credit cards may incur additional fees from their banks. Bitcoin payments are now accepted for online orders."
-  }
-]
+# sample_documents = [
+#   {
+#     title: "Company Return Policy",
+#     content: "Our return policy is designed to ensure customer satisfaction. Items can be returned within 30 days of purchase with a valid receipt. All items must be in their original condition with tags attached. For online purchases, shipping costs will be refunded only if the return is due to our error. Customized items are non-returnable unless defective. Electronics must be returned within 14 days and cannot be returned if opened unless defective."
+#   },
+#   {
+#     title: "Employee Remote Work Guidelines",
+#     content: "Remote work is available to all full-time employees after 90 days of employment. Employees must maintain core hours of 10 AM to 3 PM in their local time zone for meetings and collaboration. A reliable internet connection with minimum 10Mbps speed is required. Remote workers must attend the monthly virtual team meeting and quarterly in-person meetings. Time tracking is required through our project management system. Equipment including laptop and monitor will be provided by the company."
+#   },
+#   {
+#     title: "Product: Smart Home Hub",
+#     content: "The SmartLife Hub is our flagship smart home controller. Key features include: Voice control support for Alexa and Google Assistant, Z-Wave and Zigbee protocol support, automated scene creation, energy usage monitoring, and mobile app control. The hub can connect up to 100 devices simultaneously and includes built-in backup battery support for up to 4 hours of operation during power outages. Retail price: $199.99. Available in white and black colors."
+#   },
+#   {
+#     title: "Customer Service Standards",
+#     content: "Our customer service representatives must respond to all inquiries within 24 hours. Phone support is available 24/7 for urgent issues. Email responses should be personalized and address all customer concerns. Chat support is available Monday through Friday, 9 AM to 6 PM EST. Escalation to a supervisor is available upon customer request. All customer interactions must be logged in our CRM system with detailed notes."
+#   },
+#   {
+#     title: "Shipping Information",
+#     content: "Standard shipping takes 3-5 business days within the continental US. Express shipping (1-2 business days) is available for an additional $15. International shipping is available to select countries and typically takes 7-14 business days. Free shipping is provided on orders over $50. All orders are processed within 24 hours Monday through Friday. Tracking information is automatically sent via email once the order ships. Signature may be required for items valued over $200."
+#   },
+#   {
+#     title: "Product Warranty Terms",
+#     content: "All products come with a standard 1-year warranty covering manufacturing defects. Premium products include an extended 3-year warranty. Warranty covers parts and labor for repairs. Accidental damage is not covered unless additional protection plan is purchased. Warranty is transferable to new owners. Battery replacement is covered for the first year only. Registration must be completed within 30 days of purchase to activate warranty coverage."
+#   },
+#   {
+#     title: "Privacy Policy Highlights",
+#     content: "We collect only essential customer data needed for order processing and service improvement. Personal information is never sold to third parties. Data is encrypted using industry-standard protocols. Customers can request their data be deleted at any time. Cookie usage is limited to essential website functionality and can be disabled. Marketing emails are opt-in only and can be disabled at any time. We conduct regular security audits to ensure data protection."
+#   },
+#   {
+#     title: "Payment Methods",
+#     content: "We accept all major credit cards including Visa, MasterCard, American Express, and Discover. PayPal and Apple Pay are supported for online purchases. Corporate purchase orders are accepted for business accounts. Payment plans are available for purchases over $500 with approved credit. All transactions are processed in USD. International credit cards may incur additional fees from their banks. Bitcoin payments are now accepted for online orders."
+#   }
+# ]
 
-puts "Creating sample documents..."
+# puts "Creating sample documents..."
 
-sample_documents.each_with_index do |doc, index|
-  puts "processing document: #{doc[:title]}"
-  begin
-    # Add a 1 second delay between requests to avoid rate limiting
-    sleep(1) if index > 0
+# sample_documents.each_with_index do |doc, index|
+#   puts "processing document: #{doc[:title]}"
+#   begin
+#     # Add a 1 second delay between requests to avoid rate limiting
+#     sleep(1) if index > 0
 
-    Document.create!(doc)
-    puts "Created document: #{doc[:title]}"
-  rescue => e
-    if e.message.include?('429')
-      # If we hit rate limit, wait 2 minutes and retry
-      puts "#{e.message}"
-      puts "Rate limit hit, waiting 2 minutes..."
-      sleep(2.minutes)
-      retry
-    else
-      puts "Error creating document '#{doc[:title]}': #{e.message}"
-    end
-  end
-end
+#     Document.create!(doc)
+#     puts "Created document: #{doc[:title]}"
+#   rescue => e
+#     if e.message.include?('429')
+#       # If we hit rate limit, wait 2 minutes and retry
+#       puts "#{e.message}"
+#       puts "Rate limit hit, waiting 2 minutes..."
+#       sleep(2.minutes)
+#       retry
+#     else
+#       puts "Error creating document '#{doc[:title]}': #{e.message}"
+#     end
+#   end
+# end
 
-puts "Seed data creation completed! Created #{Document.count} documents."
+# puts "Seed data creation completed! Created #{Document.count} documents."

--- a/lib/a_i_assistant/errors.rb
+++ b/lib/a_i_assistant/errors.rb
@@ -1,27 +1,30 @@
 module AIAssistant
   module Errors
     class Base < StandardError; end
-    
+
     class PersonaError < Base; end
     class PersonaNotFoundError < PersonaError; end
     class InvalidPersonaError < PersonaError; end
-    
+
     class LLMError < Base; end
     class ModelNotSupportedError < LLMError; end
     class ConnectionError < LLMError; end
     class TimeoutError < LLMError; end
     class RateLimitError < LLMError; end
-    
+
     class EmbeddingError < Base; end
     class EmbeddingGenerationError < EmbeddingError; end
-    
+
     class DocumentError < Base; end
     class DocumentCreationError < DocumentError; end
     class DocumentNotFoundError < DocumentError; end
     class InvalidDocumentError < DocumentError; end
-    
+
     class QueryError < Base; end
     class InvalidQueryError < QueryError; end
     class QueryProcessingError < QueryError; end
+
+    class ResponseError < Base; end
+    class ResponseRecordingError < ResponseError; end
   end
-end 
+end

--- a/spec/factories/llm_responses.rb
+++ b/spec/factories/llm_responses.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :llm_response do
+    body { "MyString" }
+    token_count { 1 }
+    persona { "MyString" }
+    source { "MyString" }
+    message { nil }
+  end
+end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :message do
+    body { "MyString" }
+    embedding { "" }
+    token_count { 1 }
+    document { nil }
+  end
+end

--- a/spec/models/llm_response_spec.rb
+++ b/spec/models/llm_response_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe LlmResponse, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Message, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
### What?

- Created `Messages` and `LlmResponse` models
- Updated models associations
- Updated `chats` and `documents` controllers
- Added logic so that users can specify which documents are they asking the questions to

### Why?

- To enable capturing of the message exchanges between user and Rukia
- To improve readability in the mentioned controllers
- To ensure that chats are intended for the correct document

### Screenshots

<details>
<summary>Rukia won't retrieve documents unrelated to user query. User queries must now be addressed to the right document</summary>
<img width="1257" alt="Screenshot 2025-07-10 at 2 37 56 PM" src="https://github.com/user-attachments/assets/db85123d-8313-4572-8c04-d0e7babe36c1" />
<img width="1257" alt="Screenshot 2025-07-10 at 2 42 30 PM" src="https://github.com/user-attachments/assets/f3241d9f-fe2c-4a36-ba47-2550a7543e1c" />
</details>

<details>
<summary>File uploads requires user authentication now</summary>
<img width="1257" alt="Screenshot 2025-07-10 at 3 29 07 PM" src="https://github.com/user-attachments/assets/a22abb53-a2f8-4ae0-9531-d3a9f60e40ba" />
</details>

<details>
<summary>All documents endpoint</summary>
<img width="1257" alt="Screenshot 2025-07-10 at 3 31 09 PM" src="https://github.com/user-attachments/assets/5908a396-2e2c-4952-b323-e21c5d5f99a6" />
</details>

<details>
<summary>Retrieved messages for a specific user</summary>
<img width="1257" alt="Screenshot 2025-07-10 at 3 33 15 PM" src="https://github.com/user-attachments/assets/28e2feaa-f2ff-4e0d-bfa0-9ce8efd8bcb5" />

</details>